### PR TITLE
:feelsgood::traffic_light::bug: Run only Firefox on CI (fixes noref)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,10 +15,6 @@ dependencies:
         - uname -a && . /etc/lsb-release && echo $DISTRIB_DESCRIPTION
         - npm i -g npm@latest
         - npm -v
-        - wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-        - sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-        - sudo apt-get update
-        - sudo apt-get install google-chrome-stable
     post:
         - npm run check-deps
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,8 +1,10 @@
 const webpack = require('webpack')
 
+const isCI = !!process.env.CI
+
 module.exports = function(config) {
     config.set({
-        browsers: ['Chrome', 'Firefox'],
+        browsers: isCI ? ['Firefox'] : ['Chrome', 'Firefox'],
 
         files: [
             './src/*.test.js',


### PR DESCRIPTION
Karma tests continue to fail due to full page reload, only with
Chrome and only within CircleCI. For now, will not run tests on Chrome
in CircleCI.

related #7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/homezen/redux-variants/8)
<!-- Reviewable:end -->
