### PR TITLE
:shower: HoC - don't leak dispatch (fixes noref)

### DIFF
--- a/src/connect-variants.js
+++ b/src/connect-variants.js
@@ -31,7 +31,7 @@ const connectVariants = curry((config, ComposedComponent) => {
         )
     }))
 
-    return connect(mapStateToProps)(ComposedComponent)
+    return connect(mapStateToProps, {})(ComposedComponent)
 })
 
 export default connectVariants


### PR DESCRIPTION
- provide `mapDispatchToProps` so dispatch doesn't leak to child

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/homezen/redux-variants/45)
<!-- Reviewable:end -->
