### PR TITLE
:microscope::traffic_light: Chrome Headless & yarn (fixes noref)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,13 +13,19 @@ machine:
 dependencies:
     pre:
         - uname -a && . /etc/lsb-release && echo $DISTRIB_DESCRIPTION
-        - npm i -g npm@^4
+        - npm i -g npm@^5
         - npm -v
+        - npm i -g yarn
+        - rm -rf ~/.yarn
+    override:
+        - bundle install
+        - yarn install --no-lockfile
     post:
         # Chrome 53 / Karma issue
         - wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
         - sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
         - sudo apt-get update
+        - sudo apt-get install -y google-chrome-unstable
         - sudo apt-get install -y --only-upgrade google-chrome-stable
 
 test:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,11 +2,10 @@
 
 const webpack = require('webpack')
 
-const isCI = !!process.env.CI
 
 module.exports = function(config) {
     config.set({
-        browsers: isCI ? ['Firefox'] : ['Chrome', 'Firefox'],
+        browsers: ['ChromeHeadless', 'ChromeCanaryHeadless', 'Firefox'],
 
         files: [
             './src/*.test.js',


### PR DESCRIPTION
- Karma tests are run with Chrome & Canary Headless
- CI uses yarn to install deps