### PR TITLE
:traffic_light: Automerge testing-only deps (fixes noref)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "enabled": true,
+  "packages": [
+    {
+      "packagePatterns": [
+        "^babel.*",
+        "^chai.*",
+        "^codecov.*",
+        "^enzyme.*",
+        "^eslint.*",
+        "^karma.*",
+        "^mocha.*",
+        "^nock.*",
+        "^npm-check.*",
+        "^nyc.*",
+        "^react.*",
+        "^redux.*",
+        "^remark.*",
+        "^sinon.*",
+        "^webpack.*"
+      ],
+      "autoMerge": "minor"
+    }
+  ]
+}


### PR DESCRIPTION
Reduces PR noise for deps that are only used for testing (and thus CI
checks are sufficient to determine whether to merge)